### PR TITLE
Building medplum api without added unix user

### DIFF
--- a/medplum-api-dev.Dockerfile
+++ b/medplum-api-dev.Dockerfile
@@ -5,9 +5,6 @@ RUN apt install -y git
 
 ENV NODE_ENV development
 
-
-RUN useradd -u 8877 medplum
-
 WORKDIR /usr/src/medplum
 
 COPY package.json .
@@ -26,6 +23,8 @@ RUN npm run build -- --filter=@medplum/server
 
 EXPOSE 5000 8103
 
-USER medplum
+# Add healthcheck
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8103/healthcheck || exit 1
 
 ENTRYPOINT [ "node", "--require", "./packages/server/dist/otel/instrumentation.js", "packages/server/dist/index.js" , "aws:us-east-2:/medplum/dev/"]


### PR DESCRIPTION
This pull request includes changes to the `medplum-api-dev.Dockerfile` to improve the Docker image setup and add a health check mechanism.

Dockerfile improvements:

* Removed the creation of a `medplum` user and the `USER medplum` directive. [[1]](diffhunk://#diff-d0bb8b0f44aeef440252d93bef446c07e3d9d3d25c3f786c785cb9522d49045bL8-L10) [[2]](diffhunk://#diff-d0bb8b0f44aeef440252d93bef446c07e3d9d3d25c3f786c785cb9522d49045bL29-R28)
* Added a health check to ensure the service is running correctly by periodically checking the `/healthcheck` endpoint.